### PR TITLE
Implemented IoC container with command-based scope management

### DIFF
--- a/src/main/java/org/millerM907/hw05_ioc_container/base/Command.java
+++ b/src/main/java/org/millerM907/hw05_ioc_container/base/Command.java
@@ -1,0 +1,5 @@
+package org.millerM907.hw05_ioc_container.base;
+
+public interface Command {
+    void execute();
+}

--- a/src/main/java/org/millerM907/hw05_ioc_container/base/DependencyResolver.java
+++ b/src/main/java/org/millerM907/hw05_ioc_container/base/DependencyResolver.java
@@ -1,0 +1,6 @@
+package org.millerM907.hw05_ioc_container.base;
+
+public interface DependencyResolver {
+
+    <T> T resolve(String key, Object... args);
+}

--- a/src/main/java/org/millerM907/hw05_ioc_container/impl/dependency_resolve_commands/ClearCurrentScopeCommand.java
+++ b/src/main/java/org/millerM907/hw05_ioc_container/impl/dependency_resolve_commands/ClearCurrentScopeCommand.java
@@ -1,0 +1,11 @@
+package org.millerM907.hw05_ioc_container.impl.dependency_resolve_commands;
+
+import org.millerM907.hw05_ioc_container.base.Command;
+import org.millerM907.hw05_ioc_container.impl.ioc.IoC;
+
+public class ClearCurrentScopeCommand implements Command {
+    @Override
+    public void execute() {
+        IoC.<Command>resolve("IoC.Scope.Current.Clear.Internal").execute();
+    }
+}

--- a/src/main/java/org/millerM907/hw05_ioc_container/impl/dependency_resolve_commands/RegisterDependencyCommand.java
+++ b/src/main/java/org/millerM907/hw05_ioc_container/impl/dependency_resolve_commands/RegisterDependencyCommand.java
@@ -1,0 +1,21 @@
+package org.millerM907.hw05_ioc_container.impl.dependency_resolve_commands;
+
+import org.millerM907.hw05_ioc_container.base.Command;
+import org.millerM907.hw05_ioc_container.impl.ioc.IoC;
+
+import java.util.function.Function;
+
+public class RegisterDependencyCommand implements Command {
+    private final String key;
+    private final Function<Object[], Object> factory;
+
+    public RegisterDependencyCommand(String key, Function<Object[], Object> factory) {
+        this.key = key;
+        this.factory = factory;
+    }
+
+    @Override
+    public void execute() {
+        IoC.<Command>resolve("IoC.Register.Internal", key, factory).execute();
+    }
+}

--- a/src/main/java/org/millerM907/hw05_ioc_container/impl/dependency_resolve_commands/SetCurrentScopeCommand.java
+++ b/src/main/java/org/millerM907/hw05_ioc_container/impl/dependency_resolve_commands/SetCurrentScopeCommand.java
@@ -1,0 +1,17 @@
+package org.millerM907.hw05_ioc_container.impl.dependency_resolve_commands;
+
+import org.millerM907.hw05_ioc_container.base.Command;
+import org.millerM907.hw05_ioc_container.impl.ioc.IoC;
+
+public class SetCurrentScopeCommand implements Command {
+    private final Object scope;
+
+    public SetCurrentScopeCommand(Object scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    public void execute() {
+        IoC.<Command>resolve("IoC.Scope.Current.Set.Internal", scope).execute();
+    }
+}

--- a/src/main/java/org/millerM907/hw05_ioc_container/impl/ioc/DependencyResolverImpl.java
+++ b/src/main/java/org/millerM907/hw05_ioc_container/impl/ioc/DependencyResolverImpl.java
@@ -1,0 +1,32 @@
+package org.millerM907.hw05_ioc_container.impl.ioc;
+
+import org.millerM907.hw05_ioc_container.base.DependencyResolver;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public class DependencyResolverImpl implements DependencyResolver {
+
+    private final Map<String, Function<Object[], Object>> scope;
+
+    public DependencyResolverImpl(Map<String, Function<Object[], Object>> scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    public <T> T resolve(String dependency, Object... args) {
+        Map<String, Function<Object[], Object>> current = scope;
+        while (true) {
+            Function<Object[], Object> strategy = current.get(dependency);
+            if (strategy != null) {
+                return (T) strategy.apply(args);
+            } else {
+                Function<Object[], Object> parentResolver = current.get("IoC.Scope.Parent");
+                if (parentResolver == null) {
+                    throw new IllegalStateException("No parent scope found for dependency: " + dependency);
+                }
+                current = (Map<String, Function<Object[], Object>>) parentResolver.apply(args);
+            }
+        }
+    }
+}

--- a/src/main/java/org/millerM907/hw05_ioc_container/impl/ioc/InitCommand.java
+++ b/src/main/java/org/millerM907/hw05_ioc_container/impl/ioc/InitCommand.java
@@ -1,0 +1,70 @@
+package org.millerM907.hw05_ioc_container.impl.ioc;
+
+import org.millerM907.hw05_ioc_container.base.Command;
+import org.millerM907.hw05_ioc_container.base.DependencyResolver;
+import org.millerM907.hw05_ioc_container.impl.dependency_resolve_commands.ClearCurrentScopeCommand;
+import org.millerM907.hw05_ioc_container.impl.dependency_resolve_commands.RegisterDependencyCommand;
+import org.millerM907.hw05_ioc_container.impl.dependency_resolve_commands.SetCurrentScopeCommand;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+public class InitCommand implements Command {
+
+    private static final ThreadLocal<Object> currentScopes = new ThreadLocal<>();
+    private static final ConcurrentHashMap<String, Function<Object[], Object>> rootScope = new ConcurrentHashMap<>();
+    private static boolean alreadyInitialized = false;
+
+    @Override
+    public void execute() {
+        if (alreadyInitialized) return;
+
+        synchronized (rootScope) {
+            rootScope.put("IoC.Scope.Current.Set", args -> new SetCurrentScopeCommand(args[0]));
+            rootScope.put("IoC.Scope.Current.Clear", args -> new ClearCurrentScopeCommand());
+            rootScope.put("IoC.Scope.Current", args -> currentScopes.get() != null ? currentScopes.get() : rootScope);
+            rootScope.put("IoC.Scope.Parent", args -> { throw new IllegalStateException("Root scope has no parent"); });
+            rootScope.put("IoC.Scope.Create.Empty", args -> new HashMap<String, Function<Object[], Object>>());
+            rootScope.put("IoC.Scope.Create", args -> {
+                Map<String, Function<Object[], Object>> newScope = IoC.resolve("IoC.Scope.Create.Empty");
+                Object parent = args.length > 0 ? args[0] : IoC.resolve("IoC.Scope.Current");
+                newScope.put("IoC.Scope.Parent", __ -> parent);
+                return newScope;
+            });
+            rootScope.put("IoC.Register", args -> new RegisterDependencyCommand((String) args[0], (Function<Object[], Object>) args[1]));
+            rootScope.put("IoC.Scope.Current.Set.Internal", args -> new Command() {
+                @Override
+                public void execute() {
+                    InitCommand.currentScopes.set(args[0]);
+                }
+            });
+            rootScope.put("IoC.Scope.Current.Clear.Internal", args -> new Command() {
+                @Override
+                public void execute() {
+                    InitCommand.currentScopes.remove();
+                }
+            });
+            rootScope.put("IoC.Register.Internal", args -> new Command() {
+                @SuppressWarnings("unchecked")
+                @Override
+                public void execute() {
+                    Map<String, Function<Object[], Object>> scope =
+                            (Map<String, Function<Object[], Object>>) IoC.resolve("IoC.Scope.Current");
+                    String key = (String) args[0];
+                    Function<Object[], Object> factory = (Function<Object[], Object>) args[1];
+                    scope.put(key, factory);
+                }
+            });
+
+            IoC.setResolveStrategy((dependency, args) -> {
+                Object scope = currentScopes.get() != null ? currentScopes.get() : rootScope;
+                DependencyResolver resolver = new DependencyResolverImpl((Map<String, Function<Object[], Object>>) scope);
+                return resolver.resolve(dependency, args);
+            });
+
+            alreadyInitialized = true;
+        }
+    }
+}

--- a/src/main/java/org/millerM907/hw05_ioc_container/impl/ioc/IoC.java
+++ b/src/main/java/org/millerM907/hw05_ioc_container/impl/ioc/IoC.java
@@ -1,0 +1,20 @@
+package org.millerM907.hw05_ioc_container.impl.ioc;
+
+import java.util.function.BiFunction;
+
+public final class IoC {
+
+    private static BiFunction<String, Object[], Object> strategy =
+            (dep, args) -> { throw new IllegalStateException("IoC is not initialized"); };
+
+    private IoC() {}
+
+    @SuppressWarnings("unchecked")
+    public static <T> T resolve(String key, Object... args) {
+        return (T) strategy.apply(key, args);
+    }
+
+    public static void setResolveStrategy(BiFunction<String, Object[], Object> newStrategy) {
+        strategy = newStrategy;
+    }
+}

--- a/src/test/java/org/millerM907/hw05_ioc_container/IoCTest.java
+++ b/src/test/java/org/millerM907/hw05_ioc_container/IoCTest.java
@@ -1,0 +1,181 @@
+package org.millerM907.hw05_ioc_container;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.millerM907.hw05_ioc_container.base.Command;
+import org.millerM907.hw05_ioc_container.impl.ioc.InitCommand;
+import org.millerM907.hw05_ioc_container.impl.ioc.IoC;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IoCTest {
+
+    @BeforeEach
+    void setUp() {
+        new InitCommand().execute();
+    }
+
+    @Test
+    @DisplayName("Should register core dependencies in root scope")
+    void givenIoCNotInitialized_whenInitExecuted_thenRootScopeIsRegistered() {
+        Object currentScope = IoC.resolve("IoC.Scope.Current");
+
+
+        assertNotNull(currentScope);
+        assertTrue(currentScope instanceof ConcurrentHashMap);
+    }
+
+    @Test
+    @DisplayName("Should not reinitialize IoC when InitCommand executed twice")
+    void givenIoCInitialized_whenInitExecutedAgain_thenNoExceptionThrown() {
+        new InitCommand().execute();
+
+
+        assertDoesNotThrow(() -> IoC.resolve("IoC.Scope.Current"));
+    }
+
+    @Test
+    @DisplayName("Should register simple dependency in root scope")
+    void givenIoCInitialized_whenRegisterSimpleDependency_thenDependencyIsResolvable() {
+        Command registerCmd = IoC.<Command>resolve(
+                "IoC.Register",
+                "foo",
+                (Function<Object[], Object>) args -> "bar"
+        );
+
+
+        registerCmd.execute();
+
+
+        assertEquals("bar", IoC.resolve("foo"));
+    }
+
+    @Test
+    @DisplayName("Should register dependency with arguments and resolve correctly")
+    void givenIoCInitialized_whenRegisterDependencyWithArgs_thenResolvedValueMatches() {
+        Command registerCmd = IoC.<Command>resolve(
+                "IoC.Register",
+                "sum",
+                (Function<Object[], Object>) args -> (int) args[0] + (int) args[1]
+        );
+
+
+        registerCmd.execute();
+
+
+        assertEquals(5, IoC.<Integer>resolve("sum", 2, 3));
+    }
+
+    @Test
+    @DisplayName("Should switch to parent scope after clearing current scope")
+    void givenChildScopeIsCurrent_whenClearScopeExecuted_thenCurrentScopeSwitchedToParent() {
+        Map<String, Function<Object[], Object>> childScope =
+                IoC.<Map<String, Function<Object[], Object>>>resolve("IoC.Scope.Create");
+        IoC.<Command>resolve("IoC.Scope.Current.Set", childScope).execute();
+
+        Map<String, Function<Object[], Object>> currentScopeBeforeClear =
+                IoC.<Map<String, Function<Object[], Object>>>resolve("IoC.Scope.Current");
+        assertSame(childScope, currentScopeBeforeClear, "Current scope should be childScope");
+
+        Command clearCmd = IoC.<Command>resolve("IoC.Scope.Current.Clear");
+
+
+        clearCmd.execute();
+
+
+        Map<String, Function<Object[], Object>> currentScopeAfterClear =
+                IoC.<Map<String, Function<Object[], Object>>>resolve("IoC.Scope.Current");
+        assertNotSame(childScope, currentScopeAfterClear, "Current scope should no longer be childScope");
+    }
+
+    @Test
+    @DisplayName("Child scope should override parent dependency and revert after clearing")
+    void givenChildScopeOverridesParent_whenCleared_thenParentDependencyResolves() {
+        IoC.<Command>resolve("IoC.Register", "foo", (Function<Object[], Object>) args -> "root").execute();
+        Map<String, Function<Object[], Object>> rootScopeMap =
+                IoC.<Map<String, Function<Object[], Object>>>resolve("IoC.Scope.Current");
+
+        Map<String, Function<Object[], Object>> childScope =
+                IoC.<Map<String, Function<Object[], Object>>>resolve("IoC.Scope.Create", rootScopeMap);
+        childScope.put("foo", args -> "child");
+
+        IoC.<Command>resolve("IoC.Scope.Current.Set", childScope).execute();
+
+        assertEquals("child", IoC.<String>resolve("foo"));
+
+
+        IoC.<Command>resolve("IoC.Scope.Current.Clear").execute();
+
+        assertEquals("root", IoC.<String>resolve("foo"));
+    }
+
+    @Test
+    @DisplayName("Should resolve dependency from parent scope when not present in child")
+    void givenDependencyInParent_whenResolvingFromChild_thenParentDependencyReturned() {
+        IoC.<Command>resolve("IoC.Register", "foo", (Function<Object[], Object>) args -> "root").execute();
+        Map<String, Function<Object[], Object>> childScope = IoC.resolve("IoC.Scope.Create");
+        IoC.<Command>resolve("IoC.Scope.Current.Set", childScope).execute();
+
+
+        assertEquals("root", IoC.resolve("foo"));
+    }
+
+    @Test
+    @DisplayName("Resolving unknown dependency should throw exception")
+    void givenUnknownDependency_whenResolve_thenThrowsException() {
+        assertThrows(IllegalStateException.class, () -> IoC.resolve("unknown"));
+    }
+
+    @Test
+    @DisplayName("Internal registration should make dependency resolvable")
+    void givenInternalRegister_whenExecuted_thenDependencyIsResolvable() {
+        Command registerInternalCmd = IoC.<Command>resolve(
+                "IoC.Register.Internal",
+                "foo",
+                (Function<Object[], Object>) args -> "bar"
+        );
+
+
+        registerInternalCmd.execute();
+
+
+        assertEquals("bar", IoC.resolve("foo"));
+    }
+
+    @Test
+    @DisplayName("ThreadLocal scopes should be isolated across threads")
+    void givenTwoThreads_whenScopesSetSeparately_thenDependenciesAreIsolated() throws InterruptedException {
+        AtomicReference<String> result1 = new AtomicReference<>();
+        AtomicReference<String> result2 = new AtomicReference<>();
+
+        Thread t1 = new Thread(() -> {
+            Map<String, Function<Object[], Object>> scope1 = IoC.resolve("IoC.Scope.Create");
+            scope1.put("foo", args -> "thread1");
+            IoC.<Command>resolve("IoC.Scope.Current.Set", scope1).execute();
+            result1.set(IoC.resolve("foo"));
+        });
+
+        Thread t2 = new Thread(() -> {
+            Map<String, Function<Object[], Object>> scope2 = IoC.resolve("IoC.Scope.Create");
+            scope2.put("foo", args -> "thread2");
+            IoC.<Command>resolve("IoC.Scope.Current.Set", scope2).execute();
+            result2.set(IoC.resolve("foo"));
+        });
+
+
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+
+
+        assertEquals("thread1", result1.get());
+        assertEquals("thread2", result2.get());
+    }
+}


### PR DESCRIPTION
* Applied the Command design pattern.
* Introduced IoC container resilient to changing requirements:
  - InitCommand — bootstraps the container.
  - RegisterDependencyCommand — registers dependencies in the container.
  - ClearCurrentScopeCommand — clears the current IoC scope.
* IoC functionality is covered by unit tests.