### PR TITLE
Implemented auto-generation of adapters for user-defined objects

### DIFF
--- a/src/main/java/org/millerM907/hw06_generation_adapters_by_interface/AdapterFactory.java
+++ b/src/main/java/org/millerM907/hw06_generation_adapters_by_interface/AdapterFactory.java
@@ -1,0 +1,65 @@
+package org.millerM907.hw06_generation_adapters_by_interface;
+
+import org.millerM907.hw02_stable_abstractions.space_battle.ConfigurableObject;
+import org.millerM907.hw05_ioc_container.base.Command;
+import org.millerM907.hw05_ioc_container.impl.ioc.IoC;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Locale;
+
+public class AdapterFactory {
+
+    @SuppressWarnings("unchecked")
+    public static <T> T createAdapter(Class<T> interfaceClass, ConfigurableObject obj) {
+        if (!interfaceClass.isInterface()) {
+            throw new IllegalArgumentException("Only interfaces are supported");
+        }
+
+        InvocationHandler handler = new UniversalAdapterHandler(interfaceClass, obj);
+
+        return (T) Proxy.newProxyInstance(
+                interfaceClass.getClassLoader(),
+                new Class<?>[]{interfaceClass},
+                handler
+        );
+    }
+
+    private static class UniversalAdapterHandler implements InvocationHandler {
+        private static final String GET_KEY_TEMPLATE = "%s:%s.get";
+        private static final String SET_KEY_TEMPLATE = "%s:%s.set";
+
+        private final Class<?> interfaceClass;
+        private final ConfigurableObject obj;
+
+        UniversalAdapterHandler(Class<?> interfaceClass, ConfigurableObject obj) {
+            this.interfaceClass = interfaceClass;
+            this.obj = obj;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            String methodName = method.getName();
+            String interfaceName = interfaceClass.getName();
+
+            if (methodName.startsWith("get")) {
+                String property = decapitalize(methodName.substring(3));
+                String key = String.format(GET_KEY_TEMPLATE, interfaceName, property);
+                return IoC.resolve(key, obj);
+            } else if (methodName.startsWith("set")) {
+                String property = decapitalize(methodName.substring(3));
+                String key = String.format(SET_KEY_TEMPLATE, interfaceName, property);
+                IoC.<Command>resolve(key, obj, args[0]).execute();
+                return null;
+            } else {
+                throw new UnsupportedOperationException("Unsupported method: " + methodName);
+            }
+        }
+
+        private String decapitalize(String s) {
+            if (s == null || s.isEmpty()) return s;
+            return s.substring(0, 1).toLowerCase(Locale.ROOT) + s.substring(1);
+        }
+    }
+}

--- a/src/main/java/org/millerM907/hw06_generation_adapters_by_interface/spaceship/operations/Movable.java
+++ b/src/main/java/org/millerM907/hw06_generation_adapters_by_interface/spaceship/operations/Movable.java
@@ -1,0 +1,9 @@
+package org.millerM907.hw06_generation_adapters_by_interface.spaceship.operations;
+
+import org.millerM907.hw02_stable_abstractions.space_battle.core.Vector;
+
+public interface Movable {
+    Vector getPosition();
+    void setPosition(Vector newValue);
+    Vector getVelocity();
+}

--- a/src/test/java/org/millerM907/hw06_generation_adapters_by_interface/AdapterFactoryTest.java
+++ b/src/test/java/org/millerM907/hw06_generation_adapters_by_interface/AdapterFactoryTest.java
@@ -1,0 +1,84 @@
+package org.millerM907.hw06_generation_adapters_by_interface;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.millerM907.hw02_stable_abstractions.space_battle.ConfigurableObject;
+import org.millerM907.hw02_stable_abstractions.space_battle.core.Vector;
+import org.millerM907.hw05_ioc_container.base.Command;
+import org.millerM907.hw05_ioc_container.impl.ioc.IoC;
+import org.millerM907.hw06_generation_adapters_by_interface.spaceship.operations.Movable;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class AdapterFactoryTest {
+
+    private ConfigurableObject obj;
+
+    @BeforeEach
+    void setUp() {
+        obj = mock(ConfigurableObject.class);
+
+        String interfaceName = Movable.class.getName();
+
+        IoC.setResolveStrategy((key, args) -> {
+            if (key.equals(interfaceName + ":position.get")) {
+                return new Vector(1, 2);
+            }
+            if (key.equals(interfaceName + ":velocity.get")) {
+                return new Vector(4, 5);
+            }
+            if (key.equals(interfaceName + ":position.set")) {
+                return (Command) () -> obj.setProperty("position", args[1]);
+            }
+            throw new IllegalStateException("Unexpected key: " + key);
+        });
+    }
+
+    @Test
+    @DisplayName("Should return value from IoC when getPosition is called on Movable adapter")
+    void givenMovableAdapter_whenGetPosition_thenReturnsValueFromIoC() {
+        Movable adapter = AdapterFactory.createAdapter(Movable.class, obj);
+
+        Vector result = adapter.getPosition();
+
+        assertEquals(new Vector(1, 2), result);
+    }
+
+    @Test
+    @DisplayName("Should return value from IoC when getVelocity is called on Movable adapter")
+    void givenMovableAdapter_whenGetVelocity_thenReturnsValueFromIoC() {
+        Movable adapter = AdapterFactory.createAdapter(Movable.class, obj);
+
+        Vector result = adapter.getVelocity();
+
+        assertEquals(new Vector(4, 5), result);
+    }
+
+    @Test
+    @DisplayName("Should execute IoC command when setPosition is called on Movable adapter")
+    void givenMovableAdapter_whenSetPosition_thenIoCCommandIsExecuted() {
+        Movable adapter = AdapterFactory.createAdapter(Movable.class, obj);
+        Vector newPos = new Vector(7, 8);
+
+        adapter.setPosition(newPos);
+
+        verify(obj).setProperty("position", newPos);
+    }
+
+    @Test
+    @DisplayName("Should throw exception when unsupported method is called on Movable adapter")
+    void givenMovableAdapter_whenUnsupportedMethod_thenThrowsException() {
+        Movable adapter = AdapterFactory.createAdapter(Movable.class, obj);
+
+        assertThrows(UnsupportedOperationException.class, adapter::toString);
+    }
+
+    @Test
+    @DisplayName("Should throw exception when trying to create adapter for non-interface class")
+    void givenNonInterface_whenCreateAdapter_thenThrowsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AdapterFactory.createAdapter(Vector.class, obj));
+    }
+}

--- a/src/test/java/org/millerM907/hw06_generation_adapters_by_interface/DynamicGenerationAdapterByIoCTest.java
+++ b/src/test/java/org/millerM907/hw06_generation_adapters_by_interface/DynamicGenerationAdapterByIoCTest.java
@@ -1,0 +1,72 @@
+package org.millerM907.hw06_generation_adapters_by_interface;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.millerM907.hw02_stable_abstractions.space_battle.ConfigurableObject;
+import org.millerM907.hw02_stable_abstractions.space_battle.core.Vector;
+import org.millerM907.hw05_ioc_container.base.Command;
+import org.millerM907.hw05_ioc_container.impl.ioc.InitCommand;
+import org.millerM907.hw05_ioc_container.impl.ioc.IoC;
+import org.millerM907.hw06_generation_adapters_by_interface.spaceship.operations.Movable;
+
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class DynamicGenerationAdapterByIoCTest {
+
+    private ConfigurableObject obj;
+
+    @BeforeEach
+    void setUp() {
+        new InitCommand().execute();
+
+
+        obj = mock(ConfigurableObject.class);
+
+        String interfaceName = Movable.class.getName();
+
+        Command registerPosition = IoC.resolve(
+                "IoC.Register",
+                interfaceName + ":position.get",
+                (Function<Object[], Object>) args -> new Vector(1, 2)
+        );
+        registerPosition.execute();
+
+
+        Command registerVelocity = IoC.resolve(
+                "IoC.Register",
+                interfaceName + ":velocity.get",
+                (Function<Object[], Object>) args -> new Vector(3, 4)
+        );
+        registerVelocity.execute();
+    }
+
+    @Test
+    @DisplayName("Should create adapter via IoC when Adapter strategy is registered")
+    void givenAdapterRegisteredInIoC_whenResolveAdapter_thenAdapterWorksCorrectly() {
+        Command registerAdapter = IoC.resolve(
+                "IoC.Register",
+                "Adapter",
+                (Function<Object[], Object>) args -> {
+                    Class<?> iface = (Class<?>) args[0];
+                    ConfigurableObject obj = (ConfigurableObject) args[1];
+                    return AdapterFactory.createAdapter(iface, obj);
+                }
+        );
+        registerAdapter.execute();
+
+
+        Movable adapter = IoC.resolve("Adapter", Movable.class, obj);
+
+
+        Vector pos = adapter.getPosition();
+        assertEquals(new Vector(1, 2), pos);
+
+
+        Vector vel = adapter.getVelocity();
+        assertEquals(new Vector(3, 4), vel);
+    }
+}


### PR DESCRIPTION
* Introduced AdapterFactory to generate adapters for ConfigurableObject to target interfaces (e.g., Movable).
* Ensured extensibility via IoC-based command injection, replacing hardcoded logic and preserving the Open-Closed Principle.
* Enabled adapter creation through IoC "Adapter" strategy (e.g., DynamicGenerationAdapterByIoCTest).
* Added unit tests for AdapterFactory.